### PR TITLE
Server freezing bug fixed

### DIFF
--- a/Server/RSPET_server.py
+++ b/Server/RSPET_server.py
@@ -429,6 +429,8 @@ while True:
         list_connected_commands()
         while True:
             command = raw_input("["+cur_host_ip+"]~$ ")
+            if not command:
+                continue
             command = command.split(" ")
             comm_body = command[0]
             try:


### PR DESCRIPTION
Common mistake on servers, when client sent you "empty" request client freezing.Tested on xp s3;

![alt tag](http://i.hizliresim.com/PkmAY6.jpg)

idea very simple if request is empty jmp to begining ..
