### PR TITLE
Fixed file path in Make_Binary function.

### DIFF
--- a/Server/Plugins/files.py
+++ b/Server/Plugins/files.py
@@ -153,7 +153,7 @@ class Files(Plugin):
             try:
                 remote_file = args[1]
             except IndexError:
-                remote_file = local_file
+                remote_file = local_file.split("/")[-1]
             for host in hosts:
                 try:
                     host.send(host.command_dict['getBinary'])


### PR DESCRIPTION
Okay, now it works fine,
of course remote execution need execution permissions to be set on the remote file,
and this still has to be done manually.
